### PR TITLE
현재상태 체크박스에 표시와 확인 팝업 추가

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -42,6 +42,7 @@ gettext.bindtextdomain(APP, LOCALE_DIR)
 gettext.textdomain(APP)
 _ = gettext.gettext
 
+
 def on_checkbutton_toggled(button, name):
     if button.get_active():
         state = "Active"
@@ -49,8 +50,76 @@ def on_checkbutton_toggled(button, name):
         state = "Inactive"
     print("Common handler: Checkbutton " + name + " toggled, state is " + state + " Label : " + button.get_label() + " Name : " + name )
 
-class Handler:
-    def onButtonPressed(self, button):
+# set check buttons status with existing rules file
+def set_status():
+    initial_status = [False,False,False]
+    try:
+        with open("/etc/udev/rules.d/50-usb-lockdown.rules", "r") as rulefile:
+            ruledata = rulefile.read()
+            
+            # strings to read from existing rules file
+            mass_storage_line = 'ACTION=="add", SUBSYSTEMS=="usb", ENV{DEVTYPE}=="usb_interface", ATTRS{bInterfaceClass}=="08", RUN+="/bin/bash -c \'[[ -f \\\"/sys$devpath/authorized\\\" ]] && echo 0 | tee \\\"/sys$devpath/authorized\\\" | tee -a /tmp/usb-lockdown.log\'"'
+            printer_line = 'ACTION=="add", SUBSYSTEMS=="usb", ENV{DEVTYPE}=="usb_interface", ATTRS{bInterfaceClass}=="07", RUN+="/bin/bash -c \'[[ -f \\\"/sys$devpath/authorized\\\" ]] && echo 0 | tee \\\"/sys$devpath/authorized\\\" | tee -a /tmp/usb-lockdown.log\'"'
+            hid_line = 'ACTION=="add", SUBSYSTEMS=="usb", ENV{DEVTYPE}=="usb_interface", ATTRS{bInterfaceClass}=="0e", RUN+="/bin/bash -c \'[[ -f \\\"/sys$devpath/authorized\\\" ]] && echo 0 | tee \\\"/sys$devpath/authorized\\\" | tee -a /tmp/usb-lockdown.log\'"'
+        
+            # set check button status if each string exists in rules file
+            if mass_storage_line in ruledata:
+                checkb1.set_active(True)
+                initial_status[0] = True
+            if printer_line in ruledata:
+                checkb2.set_active(True)
+                initial_status[1] = True
+            if hid_line in ruledata:
+                checkb3.set_active(True)
+                initial_status[2] = True
+            rulefile.close()
+
+    # rules file may not exist
+    except FileNotFoundError:
+        print('rules file doesn\'t exist')
+
+    return initial_status
+
+# confirm before apply
+def confirm(message):
+    # when quit button pressed
+    if message=='quit':
+        dialog = Gtk.MessageDialog(
+                            buttons=Gtk.ButtonsType.YES_NO)
+        dialog.props.text = _("Do you want to apply the changes?")
+        response = dialog.run()
+        dialog.destroy()
+
+        # Apply when the user presses the YES button
+        if response == Gtk.ResponseType.YES:
+            print('YES button pressed')
+            return True
+        else:
+            print('NO button pressed')
+            return False
+
+    # when apply button pressed
+    elif message=='stay':
+        # Show confirm message dialog
+        dialog = Gtk.MessageDialog(
+                            buttons=Gtk.ButtonsType.OK_CANCEL)
+        dialog.props.text = _("Do you want to apply the changes?")
+        response = dialog.run()
+        dialog.destroy()
+
+        # Apply when the user presses the OK button
+        if response == Gtk.ResponseType.OK:
+            print('ok button pressed')
+            return True
+        else:
+            print('cancel button pressed')
+            return False
+    
+
+def apply(apply_event):
+    # ask before apply
+    # OK/YES button pressed
+    if confirm(apply_event):
         os.system("rm -f /etc/udev/rules.d/50-usb-lockdown.rules")
         if checkb1.get_active():
             usb_mass_storage = "lockdown"
@@ -76,9 +145,26 @@ class Handler:
         else:
             usb_hid = ""
 
-        # Do somethings here
         print("usb_mass_storage : " + usb_mass_storage + " usb_printer : " + usb_printer + " usb_hid : " + usb_hid )
         os.system("sudo systemctl restart udev")
+        # quit after apply
+        Gtk.main_quit()
+
+    # cancel button pressed
+    else:
+        print('cancled')
+
+class Handler:
+    # delete_event (quit button) handler
+    def onDelete(self, *args):
+        # apply (if changes detected) before quit
+        if initial_status[0] != checkb1.get_active() or initial_status[1] != checkb2.get_active() or initial_status[2] != checkb3.get_active():
+            apply('quit')
+        Gtk.main_quit()
+
+    # clicked (apply button) handler
+    def onButtonPressed(self, button):
+        apply('stay')
 
 
 builder = Gtk.Builder()
@@ -95,7 +181,8 @@ checkb1.connect ("toggled", on_checkbutton_toggled, "usb-mass-storage")
 checkb2.connect ("toggled", on_checkbutton_toggled, "usb-printer")
 checkb3.connect ("toggled", on_checkbutton_toggled, "usb-hid")
 
-window.connect("destroy", Gtk.main_quit)
+# set check buttons status and get initial status
+initial_status = set_status()
 
 window.show_all()
 

--- a/gui/main.glade
+++ b/gui/main.glade
@@ -4,6 +4,7 @@
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkApplicationWindow" id="window1">
     <property name="can_focus">False</property>
+    <signal name="delete_event" handler="onDelete" swapped="no"/>
     <property name="title" translatable="yes">Device Lockdown</property>
     <property name="default_width">400</property>
     <property name="default_height">230</property>

--- a/po/hamonikr-lockdown-en.po
+++ b/po/hamonikr-lockdown-en.po
@@ -117,6 +117,10 @@ msgstr ""
 msgid "4"
 msgstr ""
 
+#: gui/app.py:89(property) gui/app.py:106(property)
+msgid "Do you want to apply the changes?"
+msgstr ""
+
 #. Put one translator per line, in the form of NAME <EMAIL>, YEAR1, YEAR2
 #: gui/main.glade:0(None)
 msgid "translator-credits"

--- a/po/hamonikr-lockdown-ko.po
+++ b/po/hamonikr-lockdown-ko.po
@@ -118,6 +118,10 @@ msgstr ""
 msgid "4"
 msgstr ""
 
+#: gui/app.py:89(property) gui/app.py:106(property)
+msgid "Do you want to apply the changes?"
+msgstr "변경한 설정을 적용하시겠습니까?"
+
 #. Put one translator per line, in the form of NAME <EMAIL>, YEAR1, YEAR2
 #: gui/main.glade:0(None)
 msgid "translator-credits"


### PR DESCRIPTION
#2  해당 이슈에 대한 pr입니다.

현재 설정 상태가 체크박스에 표시되도록 하는 기능과
확인 버튼을 누르면 다시한번 체크하는 팝업 창을 추가했습니다.
자세한 수정 사항은 아래와 같습니다.
1. /gui/app.py 수정
    - 기존의 rules 파일을 읽어 차단 설정 되어 있는 장치 항목은 체크되어 출력하는 set_status() 함수 추가
    - 확인 버튼 클릭시 변경사항을 적용할지 묻는 팝업 창을 띄우는 confirm(self) 함수 추가
    - 기존에 확인 버튼 클릭시 수행되던 작업이 팝업 창에서 확인 버튼을 클릭했을 때에만 수행되도록 수정
2. po/hamonikr-lockdown-en.po 파일과 po/hamonikr-lockdown-ko.po 파일 업데이트
    - app.py 파일에 추가된 팝업창의 메세지에 대한 번역 사향을 추가